### PR TITLE
Mark LLM modelScore test as flaky

### DIFF
--- a/.github/workflows/python_tests.yaml
+++ b/.github/workflows/python_tests.yaml
@@ -34,3 +34,4 @@ jobs:
         SUPABASE_SERVICE_KEY: ${{ secrets.SUPABASE_SERVICE_KEY }}
       run: |
         pytest
+

--- a/python-sdk/setup.py
+++ b/python-sdk/setup.py
@@ -8,6 +8,7 @@ setup(
     extras_require={
         "dev": [
             "pytest",
+            "pytest-rerunfailures",
             "black>=23.0,<24",
             "flake8>=6.0,<7",
             "isort>=5.0,<6",

--- a/python-sdk/tests/test_integration.py
+++ b/python-sdk/tests/test_integration.py
@@ -16,6 +16,7 @@ from rebuff import DetectApiSuccessResponse, Rebuff
 
 
 @pytest.mark.usefixtures("server")
+@pytest.mark.flaky(reruns=5)
 def test_detect_injection(server: Generator[None, None, None]) -> None:
     # Initialize the Rebuff SDK with a real API token and URL
     rb = Rebuff(api_token="12345", api_url="http://localhost:3000")


### PR DESCRIPTION
OpenAI LLM score is non deterministic. 

See https://github.com/protectai/rebuff/actions/runs/5658814065/job/15330948518 failure