### PR TITLE
Update JS language target

### DIFF
--- a/javascript-sdk/tsconfig.json
+++ b/javascript-sdk/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es2015",
     "lib": ["dom", "dom.iterable", "esnext"],
     "module": "UMD",
     "strict": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es2015",
     "rootDir": "./",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,


### PR DESCRIPTION
When I ran `npm run build` inside `javascript-sdk`, I got this error:
```
../node_modules/langchain/node_modules/openai/core.d.ts:179:3 - error TS18028: Private identifiers are only available when targeting ECMAScript 2015 and higher.

179   #private;
```
This was likely introduced by me when I introduced Langchain in https://github.com/protectai/rebuff/pull/40.