### PR TITLE
Create function to init sdk

### DIFF
--- a/javascript-sdk/tests/index.test.ts
+++ b/javascript-sdk/tests/index.test.ts
@@ -1,12 +1,12 @@
 /* eslint-disable @typescript-eslint/no-unused-expressions */
 import { describe } from "mocha";
 import { expect } from "chai";
-import { DetectRequest, DetectResponse, TacticName, TacticResult } from "../src/interface";
+import { DetectRequest, DetectResponse, TacticName } from "../src/interface";
 import RebuffSDK from "../src/sdk";
 import { getEnvironmentVariable } from "./helpers";
 
 // Initialize the Rebuff SDK with a real API token and URL
-const rb = new RebuffSDK({
+const rb = await RebuffSDK.init({
   openai: {
     apikey: getEnvironmentVariable("OPENAI_API_KEY"),
     model: "gpt-3.5-turbo",
@@ -19,7 +19,7 @@ const rb = new RebuffSDK({
     }
   }
 });
-const rb_chroma = new RebuffSDK({
+const rb_chroma = await RebuffSDK.init({
   openai: {
     apikey: getEnvironmentVariable("OPENAI_API_KEY"),
     model: "gpt-3.5-turbo",

--- a/javascript-sdk/tsconfig.json
+++ b/javascript-sdk/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es2015",
+    "target": "es2017",
     "lib": ["dom", "dom.iterable", "esnext"],
     "module": "esnext",
     "strict": true,


### PR DESCRIPTION
Since in [allowing custom strategies](https://github.com/ristomcgehee/rebuff/pull/1/files) there are now more ways to misconfigure the SDK, I figured it would be good to create a dedicated function to initialize the SDK. This also improves the code by not having properties that don't get initialized in the constructor.

Setting `"target": "es2017"` to support top-level awaits.

Since I had issues when I made other PRs non-backwards compatible, I made this change backwards compatible. If you want to see how the code would look when we remove the public constructor, see 84a65e87801fff16464fda5a3314387b204b5b45. When I update `server/` to use `init()` instead of the constructor, I will also remove the changes in 23f664a070a195e16048cb2ae2778a1e970f77d0.