### PR TITLE
Allow trusted people to run GitHub action tests

### DIFF
--- a/.github/workflows/javascript-tests.yaml
+++ b/.github/workflows/javascript-tests.yaml
@@ -9,12 +9,16 @@ on:
     types:
       - opened
       - labeled
+      - synchronize
 
 
 jobs:
   test:
     runs-on: ubuntu-latest
-    if: contains(github.event.pull_request.labels.*.name, 'okay-to-test') || (github.event_name == 'push')
+    if: |
+      (contains(github.event.pull_request.labels.*.name, 'okay-to-test') && github.event.action == 'labeled') ||
+      contains(fromJson('["MEMBER", "COLLABORATOR"]'), github.event.pull_request.author_association) ||
+      github.event_name == 'push'
 
     steps:
       # https://github.com/actions/checkout/issues/518

--- a/.github/workflows/javascript-tests.yaml
+++ b/.github/workflows/javascript-tests.yaml
@@ -15,6 +15,10 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    # We'll run if one of the following is met:
+    # 1. The 'okay-to-test' labeled has just been added to the PR.
+    # 2. A member or collaborator opens a PR or pushes new commits to it.
+    # 3. This is a push to the main branch.
     if: |
       (contains(github.event.pull_request.labels.*.name, 'okay-to-test') && github.event.action == 'labeled') ||
       contains(fromJson('["MEMBER", "COLLABORATOR"]'), github.event.pull_request.author_association) ||

--- a/.github/workflows/python-tests.yaml
+++ b/.github/workflows/python-tests.yaml
@@ -14,6 +14,10 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    # We'll run if one of the following is met:
+    # 1. The 'okay-to-test' labeled has just been added to the PR.
+    # 2. A member or collaborator opens a PR or pushes new commits to it.
+    # 3. This is a push to the main branch.
     if: |
       (contains(github.event.pull_request.labels.*.name, 'okay-to-test') && github.event.action == 'labeled') ||
       contains(fromJson('["MEMBER", "COLLABORATOR"]'), github.event.pull_request.author_association) ||

--- a/.github/workflows/python-tests.yaml
+++ b/.github/workflows/python-tests.yaml
@@ -9,11 +9,15 @@ on:
     types:
       - opened
       - labeled
+      - synchronize
 
 jobs:
   test:
     runs-on: ubuntu-latest
-    if: contains(github.event.pull_request.labels.*.name, 'okay-to-test') || (github.event_name == 'push')
+    if: |
+      (contains(github.event.pull_request.labels.*.name, 'okay-to-test') && github.event.action == 'labeled') ||
+      contains(fromJson('["MEMBER", "COLLABORATOR"]'), github.event.pull_request.author_association) ||
+      github.event_name == 'push'
 
     steps:
       # https://github.com/actions/checkout/issues/518


### PR DESCRIPTION
Currently in order to run the python or javascript tests on a PR, we have remove and add the `okay-test-test` label. This PR makes it so that adding the label is not necessary for members and collaborators. Adding the label will still be necessary for PR's whether the author is not a member or collaborator.