### PR TITLE
Fix JS API client

### DIFF
--- a/.github/workflows/javascript-tests.yaml
+++ b/.github/workflows/javascript-tests.yaml
@@ -42,6 +42,7 @@ jobs:
           CHROMA_COLLECTION_NAME: javascript_tests
         run: |
           npm install
+          npm run build
           npm test
 
       - name: Dump docker logs

--- a/javascript-sdk/src/api.ts
+++ b/javascript-sdk/src/api.ts
@@ -44,12 +44,7 @@ export default class RebuffApi implements Rebuff {
 
   async detectInjection({
     userInput = "",
-    maxHeuristicScore = 0.75,
-    maxVectorScore = 0.9,
-    maxModelScore = 0.9,
-    runHeuristicCheck = true,
-    runVectorCheck = true,
-    runLanguageModelCheck = true,
+    tacticOverrides = [],
   }: DetectRequest): Promise<DetectResponse> {
     if (userInput === null) {
       throw new RebuffError("userInput is required");
@@ -57,12 +52,7 @@ export default class RebuffApi implements Rebuff {
     const requestData: DetectRequest = {
       userInput: "",
       userInputBase64: encodeString(userInput),
-      runHeuristicCheck: runHeuristicCheck,
-      runVectorCheck: runVectorCheck,
-      runLanguageModelCheck: runLanguageModelCheck,
-      maxVectorScore,
-      maxModelScore,
-      maxHeuristicScore,
+      tacticOverrides,
     };
 
     const response = await fetch(`${this.apiUrl}/api/detect`, {
@@ -76,10 +66,6 @@ export default class RebuffApi implements Rebuff {
     if (!response.ok) {
       throw new RebuffError((responseData as any)?.message);
     }
-    responseData.injectionDetected =
-      responseData.heuristicScore > maxHeuristicScore ||
-      responseData.modelScore > maxModelScore ||
-      responseData.vectorScore.topScore > maxVectorScore;
     return responseData;
   }
 


### PR DESCRIPTION
I realized that in #90, I left the `javascript-sdk` in a state where it doesn't compile. My reasoning for not including `javascript-sdk/src/api.ts` in that PR was because the server API had not been updated yet, so the interface would be wrong if I included these changes in `api.ts`. I forgot to take into account that the types wouldn't match and would cause a compile error. I'm including those changes now because I think it's better to have the API client not match than to have the whole project not compile. Really I just need to stop submitting breaking changes :grimacing: 

I also added `npm run build` to the CI checks to prevent this sort of thing in the future.