### PR TITLE
Fix python tests

### DIFF
--- a/.github/workflows/python-tests.yaml
+++ b/.github/workflows/python-tests.yaml
@@ -43,6 +43,10 @@ jobs:
         if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
         run: |
           make install-dev
+      - name: Install server dependencies
+        # The python tests spin up a server instance if it's not already running.
+        run: |
+          make init-server
       - name: Run tests
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}


### PR DESCRIPTION
Currently the Python tests are failing on the main branch (e.g., [this run](https://github.com/protectai/rebuff/actions/runs/7591203192/job/20678937376)) and recently updated PRs. This is due to the NPM dependencies not being installed when the python tests try to start the server.

Note that the Python tests are failing on this PR due to the way `pull_request_target` works. It's using the version of `python-tests.yaml` from the main branch which is not installing the NPM dependencies.