### PR TITLE
Fix pinecone missing API key

### DIFF
--- a/python-sdk/rebuff/detect_pi_vectorbase.py
+++ b/python-sdk/rebuff/detect_pi_vectorbase.py
@@ -63,14 +63,13 @@ def init_pinecone(api_key: str, index: str, openai_api_key: str) -> Pinecone:
     if not api_key:
         raise ValueError("Pinecone apikey definition missing")
 
-    pinecone.Pinecone(api_key=api_key)
+    pc = pinecone.Pinecone(api_key=api_key)
+    pc_index = pc.Index(index)
 
     openai_embeddings = OpenAIEmbeddings(
         openai_api_key=openai_api_key, model="text-embedding-ada-002"
     )
 
-    vector_store = Pinecone.from_existing_index(
-        index, openai_embeddings, text_key="input"
-    )
+    vector_store = Pinecone(pc_index, openai_embeddings, text_key="input")
 
     return vector_store


### PR DESCRIPTION
Fixing issue identified in #107. You only encounter this if you don't set an environment variable named `PINECONE_API_KEY` (Langchain will read from that env var if you call [Pinecone.from_existing_index](https://github.com/langchain-ai/langchain/blob/c88750d54b0faf7a3a1250bb9be093dbfa74b9fc/libs/community/langchain_community/vectorstores/pinecone.py#L370)).

Fixes #107